### PR TITLE
fix detail box

### DIFF
--- a/public/help/index.html
+++ b/public/help/index.html
@@ -304,7 +304,6 @@
 
           <h4>Using the extension</h4>
 
-          <details>
             <details>
               <summary>How do I save my changes to settings?</summary>
               <p>
@@ -332,16 +331,17 @@
               </p>
             </details>
 
-            <summary>Where did the color theme options go?</summary>
-            <p>
-              As of version 4.0.0, settings for widgets have greatly improved including allowing you to individually set
-              the colors of widgets. Due to this it no longer made sense to combine the background and text colors in
-              the same area. To set the wallpaper color, from the Settings Dashboard, click the Wallpaper section, and
-              then click the color field. To set the text colors, open the "Widget Font Styles" section in the Dashboard
-              and change the color field; or edit a specific widget and change the color from the "Widget Font Styles"
-              section within the widget's settings.
-            </p>
-          </details>
+            <details>
+              <summary>Where did the color theme options go?</summary>
+              <p>
+                As of version 4.0.0, settings for widgets have greatly improved including allowing you to individually set
+                the colors of widgets. Due to this it no longer made sense to combine the background and text colors in
+                the same area. To set the wallpaper color, from the Settings Dashboard, click the Wallpaper section, and
+                then click the color field. To set the text colors, open the "Widget Font Styles" section in the Dashboard
+                and change the color field; or edit a specific widget and change the color from the "Widget Font Styles"
+                section within the widget's settings.
+              </p>
+            </details>
 
           <details>
             <summary>Why is the widget not showing on the page?</summary>


### PR DESCRIPTION
the detail tag was in the wrong place.

As a result, the opening of the answers was not associated with the correct titles.


![image](https://github.com/Moosh-be/carettab-site/assets/388085/34cd51db-d712-457b-8f92-9831668a4142)
